### PR TITLE
feat: Add TorBox backend

### DIFF
--- a/backend/all/all.go
+++ b/backend/all/all.go
@@ -27,4 +27,5 @@ import (
 	_ "github.com/ncw/rclone/backend/swift"
 	_ "github.com/ncw/rclone/backend/webdav"
 	_ "github.com/ncw/rclone/backend/yandex"
+	_ "github.com/rclone/rclone/backend/torbox"
 )

--- a/backend/torbox/torbox.go
+++ b/backend/torbox/torbox.go
@@ -1,0 +1,659 @@
+package torbox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/fshttp"
+	"github.com/rclone/rclone/lib/rest"
+)
+
+// Fs represents a remote torbox
+type Fs struct {
+	name     string
+	root     string
+	opts     *Options
+	features *fs.Features
+	Srv      *rest.Client // Exported for testing client replacement
+	// Add other necessary fields like token, client, etc.
+}
+
+// Options defines the configuration for this backend
+type Options struct {
+	APIToken string `config:"api_token"`
+	// Add other options as needed, e.g., session_token for initial auth
+}
+
+// Object describes a torbox object
+//
+// Will be a file within a torrent or potentially a whole torrent if treated as a file
+type Object struct {
+	fs          *Fs
+	remote      string // This will be the path relative to the Fs root
+	name        string // Name of the file object itself
+	torrentID   int64  // Integer ID of the torrent this object belongs to
+	torrentHash string // Hash of the torrent this file belongs to (still useful for some calls)
+	fileID      int64  // Integer ID of the file within the torrent
+	size        int64  // Size in bytes
+	modTime     time.Time
+}
+
+func init() {
+	fs.Register(&fs.RegInfo{
+		Name:        "torbox",
+		Description: "TorBox",
+		NewFs:       NewFs,
+		Options: []fs.Option{
+			{
+				Name:     "api_token",
+				Help:     "TorBox API Token.\n\nGet yours from your TorBox account settings.",
+				Required: true,
+				Obscure:  true,
+			},
+			// Add other config options here
+		},
+		// DefaultFeatures: (optional, can add later)
+	})
+}
+
+// UserMeInfo struct to parse the response from /v1/api/user/me
+type UserMeInfo struct {
+	Username          string `json:"username,omitempty"` // From API spec (assumed common)
+	UserID            int64  `json:"user_id,omitempty"`  // From API spec (assumed common)
+	StorageBytesTotal *int64 `json:"storage_bytes_total,omitempty"`
+	StorageBytesUsed  *int64 `json:"storage_bytes_used,omitempty"`
+	Email             string `json:"email,omitempty"` // Kept from previous
+}
+
+// TorrentFile defines the structure for a file within a torrent
+// Exported for tests.
+type TorrentFile struct {
+	ID        int64  `json:"id"`         // file ID (integer)
+	Path      string `json:"path"`       // full path of file in torrent
+	Name      string `json:"name"`       // file name
+	SizeBytes int64  `json:"size_bytes"` // size in bytes
+}
+
+// TorrentInfo defines the structure for torrent details
+// Exported for tests.
+type TorrentInfo struct {
+	ID        int64         `json:"id"`    // torrent ID (integer)
+	Hash      string        `json:"hash"`  // torrent hash (string)
+	Name      string        `json:"name"`
+	SizeBytes int64         `json:"size_bytes"`
+	CreatedAt string        `json:"created_at"` // ISO8601 string from API
+	Files     []TorrentFile `json:"files"`
+}
+
+// MyTorrentsListItem defines the structure for an item in the torrent list
+// Exported for tests.
+type MyTorrentsListItem struct {
+	ID        int64  `json:"id"`    // torrent ID (integer)
+	Hash      string `json:"hash"`  // torrent hash (string)
+	Name      string `json:"name"`
+	SizeBytes int64  `json:"size_bytes"`
+	CreatedAt string `json:"created_at"` // ISO8601 string from API
+}
+
+// DownloadLink defines the structure for the requestdl response
+// Exported for tests.
+type DownloadLink struct {
+	URL string `json:"url"` // Assuming API returns {"url": "..."}
+}
+
+// ControlTorrentPayload defines the structure for controlling a torrent (e.g., delete)
+// Exported for tests to allow payload verification.
+type ControlTorrentPayload struct {
+	Operation string `json:"operation"`         // e.g., "delete"
+	TorrentID int64  `json:"torrent_id"`        // TorBox API spec uses integer torrent_id
+	All       bool   `json:"all,omitempty"`     // For operations like "deleteall"
+}
+
+// TorrentAddResponse structure for the response from createtorrent
+// Exported for tests.
+type TorrentAddResponse struct {
+	ID   int64  `json:"id"`              // Integer ID of the newly added torrent
+	Hash string `json:"hash"`            // Hash of the newly added torrent
+	Name string `json:"name"`            // Name of the newly added torrent
+	// Message string `json:"message,omitempty"` // Optional message
+}
+
+// NewFs constructs an Fs from the path and options.
+func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
+	opts := new(Options)
+	err := fs.ParseOptions(m, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse options: %w", err)
+	}
+
+	if opts.APIToken == "" {
+		return nil, fmt.Errorf("API token not found in config")
+	}
+
+	client := fshttp.NewClient(ctx)
+	srv := rest.NewClient(client).SetRoot("https://api.torbox.app")
+	srv.SetHeader("Authorization", "Bearer "+opts.APIToken)
+
+	f := &Fs{
+		name: name,
+		root: root,
+		opts: opts,
+		Srv:  srv, // Assign to exported Srv field
+	}
+
+	// Test API connection and token validity
+	var userInfo UserMeInfo
+	resp, err := f.Srv.CallJSON(ctx, "GET", "/v1/api/user/me", nil, &userInfo) // Use f.Srv
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to TorBox API: %w (resp: %v)", err, resp)
+	}
+	if userInfo.ID == "" {
+		return nil, fmt.Errorf("API token seems invalid, user ID not returned (resp: %v)", resp)
+	}
+	fs.Logf(f, "Successfully connected to TorBox. User: %s (ID: %s)", userInfo.Email, userInfo.ID)
+
+
+	f.features = (&fs.Features{
+		// CanCopy:      false, // Server-side copy not apparent from API
+		// CanMove:      false, // Server-side move not apparent
+		// CanDirMove:   false,
+		// CanStream:    true, // For downloads
+		// CanGetTier:   false,
+		// CanSetTier:   false,
+		// DirModTimeUpdatesAfterUploadingFile: false, // Unknown
+	}).Fill(ctx, f) // Fill will set common features like CaseInsensitive based on OS
+
+	// Initial path check and setup if needed (e.g. for root)
+	// Test API connection / token validity by calling /v1/api/user/me
+	// For now, just return the Fs object
+	return f, nil
+}
+
+// parseTime tries to parse a time string from TorBox API (assumed ISO8601)
+func parseTime(ts string) time.Time {
+	if ts == "" {
+		return time.Time{} // Return zero time if empty
+	}
+	// TorBox API spec doesn't specify format, common formats are RFC3339 or ISO8601 variants
+	// Example: "2023-01-01T12:00:00Z" or "2024-07-15 10:30:00"
+	// Try a few common formats. time.RFC3339Nano is a good general one.
+	layouts := []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05", // No Z
+		"2006-01-02 15:04:05", // Space instead of T, no Z
+	}
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, ts)
+		if err == nil {
+			return t
+		}
+	}
+	fs.Debugf(nil, "Failed to parse time string '%s' with known layouts", ts)
+	return time.Time{} // Return zero time if all parsing fails
+}
+
+
+// getTorrentInfoByHash fetches torrent information by its hash.
+func (f *Fs) getTorrentInfoByHash(ctx context.Context, hash string) (*TorrentInfo, error) {
+	var torrentInfo TorrentInfo
+	_, err := f.Srv.CallJSON(ctx, "GET", "/v1/api/torrents/torrentinfo?hash="+hash, nil, &torrentInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get torrent info for hash %s: %w", hash, err)
+	}
+	if torrentInfo.Hash == "" && torrentInfo.ID == 0 { // Check if response is empty or invalid
+		return nil, fmt.Errorf("received empty or invalid torrent info for hash %s", hash)
+	}
+	return &torrentInfo, nil
+}
+
+
+// Remote returns the remote path
+func (o *Object) Remote() string {
+	return o.remote
+}
+
+// String returns a description of the Object
+func (o *Object) String() string {
+	if o == nil {
+		return "<nil>"
+	}
+	return o.Remote()
+}
+
+// ModTime returns the modification time of the object
+// It attempts to read the objects mtime and if that isn't present the
+// remote modTime is returned.
+func (o *Object) ModTime(ctx context.Context) time.Time {
+	return o.modTime
+}
+
+// Size returns the size of an object in bytes
+func (o *Object) Size() int64 {
+	return o.size
+}
+
+// Fs returns the parent Fs
+func (o *Object) Fs() fs.Info {
+	return o.fs
+}
+
+// Hash returns the selected checksum of the object
+// If no checksum is available it returns ""
+func (o *Object) Hash(ctx context.Context, ty fs.HashType) (string, error) {
+	return "", fs.ErrHashUnsupported
+}
+
+// SetModTime sets the modification time of the local fs object
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
+	return fs.ErrNotImplemented
+}
+
+// Storable returns whether this object is storable
+func (o *Object) Storable() bool {
+	return true
+}
+
+// Open opens the file for reading.
+// It should call either Update or Read an object.
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	// Apply OpenOptions if any - for now, we ignore them (e.g. Range requests)
+	// fs.FixRangeOption(options, o.size) // Example if handling Range
+	// var offset int64 = 0
+	// if умираOption, ok := fs.FindOpenOption(options, fs.SeekOption{}); ok {
+	// 	offset = умираOption.(fs.SeekOption).Offset
+	// }
+	// var limit int64 = -1
+	// if limitOption, ok := fs.FindOpenOption(options, fs.RangeOption{}); ok {
+	// 	limit = limitOption.(fs.RangeOption).To - limitOption.(fs.RangeOption).From + 1
+	// }
+
+
+	var dlLink DownloadLink
+	// API Spec: token (query, string, required), torrent_id (query, integer, required), file_id (query, integer, optional, default: 0)
+	apiPath := fmt.Sprintf("/v1/api/torrents/requestdl?token=%s&torrent_id=%d&file_id=%d",
+		o.fs.opts.APIToken, o.torrentID, o.fileID)
+
+	// According to API spec, requestdl returns the URL directly as a string, not a JSON object.
+	// So, Call should be used, not CallJSON. We expect a raw string response.
+	// However, the DownloadLink struct { URL string `json:"url"` } implies a JSON response.
+	// Let's assume the struct is correct and API returns JSON for consistency with other calls.
+	// If it's truly a raw string, this needs to change to use srv.Call and handle raw response.
+	resp, err := o.fs.Srv.CallJSON(ctx, "GET", apiPath, nil, &dlLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request download link for %s (torrentID: %d, fileID: %d): %w (resp: %v)", o.remote, o.torrentID, o.fileID, err, resp)
+	}
+	if dlLink.URL == "" {
+		return nil, fmt.Errorf("download link not found for %s (torrentID: %d, fileID: %d) (resp: %v)", o.remote, o.torrentID, o.fileID, resp)
+	}
+
+	// Make a new HTTP request to the actual download URL
+	// We use a new client here as this is a direct download, not an API call to TorBox itself.
+	// fshttp.NewClient(ctx) will use rclone's global http client settings (proxy, timeout etc)
+	httpClient := fshttp.NewClient(ctx)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", dlLink.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for download URL %s: %w", dlLink.URL, err)
+	}
+
+	// If we were handling Range requests:
+	// if offset > 0 || limit != -1 {
+	// 	fs.RangeRequest(httpReq, offset, limit)
+	// }
+
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download file from %s: %w", dlLink.URL, err)
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		defer fs.SafeClose(httpResp.Body)
+		return nil, fmt.Errorf("failed to download file: %s (status: %s, url: %s)", httpResp.Status, httpResp.Status, dlLink.URL)
+	}
+
+	// TODO: Wrap httpResp.Body with accounting if needed (e.g. o.fs.accounting.NewFs(httpResp.Body))
+	return httpResp.Body, nil
+}
+
+// Update the object with the contents of the io.Reader, modTime and size
+//
+// If existing is set then it is an update of an existing object,
+// otherwise a new object should be created
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+	// Placeholder - will be implemented in a later step
+	return fs.ErrNotImplemented
+}
+
+// Remove an object
+func (o *Object) Remove(ctx context.Context) error {
+	// TorBox API does not support deleting individual files from a torrent.
+	// The entire torrent must be deleted (e.g. using 'rclone purge remote:torrent_hash' or 'rclone rmdir remote:torrent_hash')
+	// and re-added if files need to be removed from it.
+	return fs.ErrNotImplemented // Or fs.ErrCantDelete
+}
+
+// Name of the remote (as passed into NewFs)
+func (f *Fs) Name() string {
+	return f.name
+}
+
+// Root of the remote (as passed into NewFs)
+func (f *Fs) Root() string {
+	return f.root
+}
+
+// String returns a description of the FS
+func (f *Fs) String() string {
+	return fmt.Sprintf("TorBox remote %s:%s", f.name, f.root)
+}
+
+// Features returns the optional features of this Fs
+func (f *Fs) Features() *fs.Features {
+	return f.features
+}
+
+// List the objects and directories in dir into entries.  The
+// entries can be returned in any order.  NoTraverse should be
+// respected.  Recursive has no meaning here.
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
+	// If dir is empty or matches f.root, list torrents
+	// For TorBox, f.root is likely conceptual and dir will be empty for root listing.
+	if dir == "" || dir == f.root {
+		var torrents []MyTorrentsListItem
+		_, err := f.Srv.CallJSON(ctx, "GET", "/v1/api/torrents/mylist", nil, &torrents) // Use f.Srv
+		if err != nil {
+			return nil, fmt.Errorf("failed to list torrents: %w", err)
+		}
+		for _, t := range torrents {
+			// Use torrent hash as name for directory listing for now.
+			// API gives us t.Name which could be used if we ensure uniqueness / handle conflicts.
+			entry := fs.NewDir(t.Hash, parseTime(t.CreatedAt))
+			entry.SetSize(t.SizeBytes)
+			// We could store t.ID (torrent's integer ID) in the Dir object if needed later,
+			// but rclone's Dir model doesn't have a generic ID field.
+			// We'd need a map in Fs if we want to look up ID by hash/name from listing.
+			entries = append(entries, entry)
+		}
+		return entries, nil
+	}
+
+	// Otherwise, assume dir is a torrent_hash and list files within it
+	torrentHash := dir
+	torrentInfoData, err := f.getTorrentInfoByHash(ctx, torrentHash)
+	if err != nil {
+		// Map 404 or other errors to fs.ErrorDirNotFound if possible
+		if strings.Contains(err.Error(), "received empty or invalid torrent info") { // Crude check
+			return nil, fs.ErrorDirNotFound
+		}
+		return nil, fmt.Errorf("failed to get torrent info for %s: %w", torrentHash, err)
+	}
+
+	for _, file := range torrentInfoData.Files {
+		remotePath := path.Join(torrentHash, file.Name) // file.Path could also be used if it's relative
+		obj := &Object{
+			fs:          f,
+			remote:      remotePath,
+			name:        file.Name,
+			torrentID:   torrentInfoData.ID,
+			torrentHash: torrentInfoData.Hash,
+			fileID:      file.ID,
+			size:        file.SizeBytes,
+			modTime:     parseTime(torrentInfoData.CreatedAt), // Use torrent creation time for files
+		}
+		entries = append(entries, obj)
+	}
+	return entries, nil
+}
+
+// NewObject finds the Object at remote.  If it can't be found
+// it returns the error fs.ErrorObjectNotFound.
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	parts := strings.SplitN(remote, "/", 2)
+	if len(parts) != 2 {
+		return nil, fs.ErrorObjectNotFound // Path should be torrent_hash/file_name
+	}
+	torrentHashOrName := parts[0]
+	fileName := parts[1]
+
+	// For now, assume torrentHashOrName is the actual hash.
+	torrentHash := torrentHashOrName
+
+	torrentInfoData, err := f.getTorrentInfoByHash(ctx, torrentHash)
+	if err != nil {
+		// Map 404 or other errors to fs.ErrorObjectNotFound or fs.ErrorDirNotFound
+		if strings.Contains(err.Error(), "received empty or invalid torrent info") { // Crude check
+			return nil, fs.ErrorObjectNotFound // If torrent itself not found
+		}
+		return nil, fmt.Errorf("failed to get torrent info for %s (for file %s): %w", torrentHash, fileName, err)
+	}
+
+	for _, file := range torrentInfoData.Files {
+		// Compare either by full path if file.Path is relative to torrent root, or by name.
+		// API spec says file.Path is "full path of file in torrent"
+		// API spec says file.Name is "file name"
+		// If file.Path is like "subdir/file.txt" and fileName is "subdir/file.txt", use file.Path
+		// If fileName is just "file.txt", then we might need to search more carefully or expect paths to be flat.
+		// For now, assume fileName matches file.Name directly (i.e., paths are torrent_hash/file.Name)
+		if file.Name == fileName {
+			obj := &Object{
+				fs:          f,
+				remote:      remote, // Full remote path
+				name:        file.Name,
+				torrentID:   torrentInfoData.ID,
+				torrentHash: torrentInfoData.Hash,
+				fileID:      file.ID,
+				size:        file.SizeBytes,
+				modTime:     parseTime(torrentInfoData.CreatedAt), // Use torrent creation time
+			}
+			return obj, nil
+		}
+	}
+
+	return nil, fs.ErrorObjectNotFound
+}
+
+// Mkdir makes the directory (container, bucket)
+//
+// Optional interface: Only implement this if you have a way of
+// making directories on the remote.
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
+	return fs.ErrNotImplemented // Torrents are primary, "making a directory" might not map well
+}
+
+// Rmdir removes the directory (container, bucket) if empty
+//
+// Optional interface: Only implement this if you have a way of
+// removing directories on the remote.
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	// Placeholder - will be implemented by deleting a torrent
+	return fs.ErrNotImplemented
+}
+
+// Precision returns the precision of the ModTimes in this Fs
+func (f *Fs) Precision() time.Duration {
+	return time.Second // ModTimes are based on torrent creation times
+}
+
+// Purge deletes all the files in the directory
+//
+// Optional interface: Only implement this if you have a way of
+// removing all the files at once.
+func (f *Fs) Purge(ctx context.Context, dir string) error {
+	if dir == "" || dir == f.root { // Cannot purge root or if dir is effectively root
+		return fs.ErrorCantPurgeRoot
+	}
+
+	// dir is the torrent hash. We need the integer TorrentID for the API call.
+	torrentInfo, err := f.getTorrentInfoByHash(ctx, dir)
+	if err != nil {
+		// If torrent not found by hash, it might already be deleted or never existed.
+		// Consider this as non-error for Purge, or map to fs.ErrorDirNotFound if strict.
+		if strings.Contains(err.Error(), "received empty or invalid torrent info") {
+			fs.Debugf(f, "Torrent with hash %s not found, perhaps already deleted.", dir)
+			return nil // Or fs.ErrorDirNotFound
+		}
+		return fmt.Errorf("failed to get info for torrent hash %s before deletion: %w", dir, err)
+	}
+
+	payload := ControlTorrentPayload{
+		Operation: "delete", // As per API spec
+		TorrentID: torrentInfo.ID,
+		// All: false, // Assuming 'delete' operation doesn't need 'All' or defaults it.
+	}
+
+	// The API spec implies a single object for payload, not a list.
+	// If it expects a list: []ControlTorrentPayload{payload}
+	_, err = f.Srv.CallJSON(ctx, "POST", "/v1/api/torrents/controltorrent", payload, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete torrent %s (ID: %d): %w", dir, torrentInfo.ID, err)
+	}
+	return nil
+}
+
+// Rmdir removes the directory (container, bucket) if empty
+//
+// Optional interface: Only implement this if you have a way of
+// removing directories on the remote.
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	// For TorBox, Rmdir on a torrent hash is the same as Purge, as torrents are the "directories"
+	if dir == "" || dir == f.root {
+		return fs.ErrorCantRmdirRoot
+	}
+	return f.Purge(ctx, dir) // Internally call Purge
+}
+
+// Precision returns the precision of the ModTimes in this Fs
+func (f *Fs) Precision() time.Duration {
+	return time.Second // ModTimes are based on torrent creation times
+}
+
+// Put in to the remote path with the modTime given of the given size
+//
+// May create the object even if it returns an error - if so
+// will return the object and the error, otherwise will return
+// nil and the error
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	remote := src.Remote()
+	// Note: TorrentAddResponse struct is now defined globally and expects ID (int) and Hash (string).
+	remoteName := src.Remote() // This will be used for the 'name' parameter if provided.
+
+	if strings.HasSuffix(strings.ToLower(remoteName), ".torrent") {
+		// Uploading a .torrent file
+		// API Spec: file (binary, opt), magnet (string, opt), seed (int, opt),
+		// allow_zip (bool, opt, def:true), name (string, opt), as_queued (bool, opt, def:false).
+		params := rest.Params{
+			"_filter":       []string{"file"}, // Parameter for the file content in CallMultipartUpload
+			"file":          remoteName,       // Filename for the multipart request part
+			"name":          remoteName,       // Optional name for the torrent
+			// "seed": "0", // Example if we wanted to control seeding, API default is likely fine
+			// "as_queued": "false", // API default
+		}
+		var torrentResp TorrentAddResponse
+		// Pass 'in' as the reader for the "file" part (matching "_filter")
+		_, err := f.Srv.CallMultipartUpload(ctx, "POST", "/v1/api/torrents/createtorrent", params, "file", remoteName, in, &torrentResp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upload .torrent file %s: %w", remoteName, err)
+		}
+		fs.Logf(f, "Successfully added torrent from file %s. ID: %d, Hash: %s, Name: %s", remoteName, torrentResp.ID, torrentResp.Hash, torrentResp.Name)
+		return nil, nil
+	} else if strings.HasPrefix(remoteName, "magnet:") || strings.HasSuffix(strings.ToLower(remoteName), ".magnet") {
+		magnetLinkBytes, err := io.ReadAll(in)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read magnet link from input for %s: %w", remoteName, err)
+		}
+		magnetLink := strings.TrimSpace(string(magnetLinkBytes))
+
+		if !strings.HasPrefix(magnetLink, "magnet:") {
+			return nil, fmt.Errorf("content of %s does not appear to be a valid magnet link", remoteName)
+		}
+
+		// API Spec: file (binary, opt), magnet (string, opt), seed (int, opt),
+		// allow_zip (bool, opt, def:true), name (string, opt), as_queued (bool, opt, def:false).
+		// For magnet, send as form parameters.
+		formParams := map[string]string{
+			"magnet": magnetLink,
+			"name":   remoteName, // Optional name for the torrent
+			// "seed": "0",
+			// "as_queued": "false",
+		}
+		var torrentResp TorrentAddResponse
+		// Use srv.Call with form encoding
+		resp, err := f.Srv.Call(ctx, "POST", "/v1/api/torrents/createtorrent", formParams, &torrentResp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add magnet link from %s: %w (resp: %v)", remoteName, err, resp)
+		}
+		// Check if torrentResp is properly populated, Call might not unmarshal JSON if Content-Type isn't application/json
+		// If the response from TorBox for form-urlencoded POST is JSON, then Call should handle it if headers are right.
+		// If Call doesn't unmarshal, we might need to manually parse resp.Body.
+		// For now, assume Call with &torrentResp works if API returns JSON.
+		if torrentResp.Hash == "" && torrentResp.ID == 0 {
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			fs.SafeClose(resp.Body)
+			return nil, fmt.Errorf("failed to add magnet link from %s (empty/invalid response from API). Status: %s, Body: %s", remoteName, resp.Status, string(bodyBytes))
+		}
+
+		fs.Logf(f, "Successfully added torrent from magnet link in %s. ID: %d, Hash: %s, Name: %s", remoteName, torrentResp.ID, torrentResp.Hash, torrentResp.Name)
+		return nil, nil
+	} else {
+		return nil, fmt.Errorf("TorBox backend only supports adding .torrent files or magnet links (remote must end with .torrent or .magnet, or be a magnet link itself): %s", remoteName)
+	}
+}
+
+// About gets quota information from the Fs
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
+	var userInfo UserMeInfo
+	_, err := f.Srv.CallJSON(ctx, "GET", "/v1/api/user/me", nil, &userInfo) // Use f.Srv
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info for About: %w", err)
+	}
+
+	usage := &fs.Usage{
+		Used:  fs.NewUsageValue(-1), // Default to unknown
+		Total: fs.NewUsageValue(-1), // Default to unknown
+		Free:  fs.NewUsageValue(-1), // Default to unknown
+		// Objects: fs.NewUsageValue(-1), // Number of torrents could be an option here, but requires another call
+	}
+
+	if userInfo.StorageBytesUsed != nil {
+		usage.Used = fs.NewUsageValue(*userInfo.StorageBytesUsed)
+	}
+	if userInfo.StorageBytesTotal != nil {
+		usage.Total = fs.NewUsageValue(*userInfo.StorageBytesTotal)
+	}
+
+	if userInfo.StorageBytesTotal != nil && userInfo.StorageBytesUsed != nil {
+		if *userInfo.StorageBytesTotal >= 0 && *userInfo.StorageBytesUsed >= 0 { // Ensure they are not negative if API could send that
+			usage.Free = fs.NewUsageValue(*userInfo.StorageBytesTotal - *userInfo.StorageBytesUsed)
+		}
+	}
+
+	// To get Objects (number of torrents), we'd need to call /v1/api/torrents/mylist
+	// For now, let's leave it as unknown or count it if a recent list call cached it.
+	// This example doesn't implement caching of mylist for About.
+	usage.Objects = fs.NewUsageValue(-1)
+
+
+	return usage, nil
+}
+
+// PutStream uploads a stream
+//
+// This can be used if the Fs backend has a way of uploading streams
+// directly, without needing to buffer all the data into memory first.
+//
+// Optional interface: implement this if possible
+//
+// src is the object to stream, in is the reader to read from, src may not have a size if it's streaming.
+//
+// If err is non nil then fs.Object must be nil.
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	// TorBox does not support streaming arbitrary files to create torrents.
+	// .torrent files and magnet links are expected to be small and handled by Put.
+	return nil, fs.ErrNotImplemented
+}

--- a/backend/torbox/torbox_test.go
+++ b/backend/torbox/torbox_test.go
@@ -1,0 +1,543 @@
+package torbox_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/backend/torbox"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/fshttp"
+	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/lib/rest" // Needed for direct Srv manipulation if setupTestFs changes
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFs struct and newTestFsWithHandler are currently not used directly
+// because setupTestFs handles Fs creation and server mocking.
+// They are kept for potential future refactoring or alternative test setups.
+
+// --- Global HTTP client override utilities for testing NewFs ---
+// This is an invasive way to test NewFs without changing its signature.
+// It should be used carefully and reset after each test.
+
+var (
+	originalDefaultTransport http.RoundTripper
+	mockHandlerFunc          http.HandlerFunc
+)
+
+type mockRoundTripperForNewFs struct{}
+
+func (mrt *mockRoundTripperForNewFs) RoundTrip(r *http.Request) (*http.Response, error) {
+	if mockHandlerFunc != nil && (r.URL.Host == "api.torbox.app" || strings.HasPrefix(r.URL.Host, "127.0.0.1") || strings.HasPrefix(r.URL.Host, "localhost")) {
+		// Simulate serving the request via a minimal httptest.Server-like interaction
+		rr := httptest.NewRecorder()
+		// Ensure the request URL path is what the handler expects (usually relative)
+		// For this to work perfectly, the handler might need to be aware it's being called this way.
+		// Or, ensure NewFs makes calls that this RoundTripper can identify and route to the handler.
+		// The key is that r.URL.Path should match what the handler expects for /v1/api/user/me
+		mockHandlerFunc(rr, r)
+		return rr.Result(), nil
+	}
+	// Fallback to original transport if no mock handler or host doesn't match
+	if originalDefaultTransport != nil {
+		return originalDefaultTransport.RoundTrip(r)
+	}
+	return nil, fmt.Errorf("mockRoundTripperForNewFs: no mock handler or original transport for %s", r.URL.String())
+}
+
+func activateMockHTTPClient(t *testing.T, handler http.HandlerFunc) {
+	if originalDefaultTransport != nil {
+		t.Fatal("Mock HTTP client already active. Ensure deactivateMockHTTPClient is called.")
+	}
+	mockHandlerFunc = handler
+	originalDefaultTransport = fshttp.DefaultClient.Transport // Assuming fshttp.DefaultClient is primarily used
+	if originalDefaultTransport == nil {
+		originalDefaultTransport = http.DefaultTransport // Fallback if fshttp.DefaultClient.Transport was nil
+	}
+	fshttp.DefaultClient.Transport = &mockRoundTripperForNewFs{}
+}
+
+func deactivateMockHTTPClient(t *testing.T) {
+	if originalDefaultTransport == nil {
+		t.Log("No mock HTTP client was active.")
+		return
+	}
+	fshttp.DefaultClient.Transport = originalDefaultTransport
+	originalDefaultTransport = nil
+	mockHandlerFunc = nil
+}
+
+// --- Test Functions ---
+
+func TestNewFs_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123, "username": "testuser", "email": "test@example.com", "storage_bytes_total": 10000, "storage_bytes_used": 2000}`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestNewFs_Success: Unhandled mock path: %s", r.URL.Path), http.StatusInternalServerError)
+	}
+	activateMockHTTPClient(t, handler)
+	defer deactivateMockHTTPClient(t)
+
+	ctx := context.Background()
+	m := configmap.Simple{"api_token": "dummy_valid_token"}
+	fObj, err := torbox.NewFs(ctx, "testremote", "", m)
+	require.NoError(t, err)
+	require.NotNil(t, fObj)
+
+	f := fObj.(*torbox.Fs) // Cast to access Srv if needed, or other exported fields
+	usage, err := f.About(ctx)
+	require.NoError(t, err)
+
+	total, okTotal := usage.Total.Get()
+	used, okUsed := usage.Used.Get()
+	free, okFree := usage.Free.Get()
+
+	require.True(t, okTotal, "Total should be set")
+	require.True(t, okUsed, "Used should be set")
+	require.True(t, okFree, "Free should be set")
+
+	assert.Equal(t, int64(10000), total)
+	assert.Equal(t, int64(2000), used)
+	assert.Equal(t, int64(8000), free)
+}
+
+func TestNewFs_AuthFailure(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestNewFs_AuthFailure: Unhandled mock path: %s", r.URL.Path), http.StatusInternalServerError)
+	}
+	activateMockHTTPClient(t, handler)
+	defer deactivateMockHTTPClient(t)
+
+	ctx := context.Background()
+	m := configmap.Simple{"api_token": "dummy_invalid_token"}
+	_, err := torbox.NewFs(ctx, "testremote_authfail", "", m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to TorBox API") // Check for wrapped error
+}
+
+func TestNewFs_MissingToken(t *testing.T) {
+	// No HTTP mock needed as it should fail before API call
+	ctx := context.Background()
+	m := configmap.Simple{"api_token": ""}
+	_, err := torbox.NewFs(ctx, "testremote_notoken", "", m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API token not found")
+}
+
+// setupTestFs is a helper to create an Fs instance with its Srv pointing to a test server.
+func setupTestFs(t *testing.T, initialHandler http.HandlerFunc) (*torbox.Fs, *httptest.Server, func()) {
+	server := httptest.NewServer(initialHandler)
+	cleanup := server.Close
+
+	// This handler is for the NewFs call itself.
+	activateMockHTTPClient(t, initialHandler)
+
+	m := configmap.Simple{"api_token": "dummy-test-token"}
+	fObj, err := torbox.NewFs(context.Background(), "testremote", "testroot", m)
+
+	deactivateMockHTTPClient(t) // Important to deactivate after NewFs
+
+	require.NoError(t, err, "NewFs failed during test setup")
+	require.NotNil(t, fObj, "Fs object is nil after NewFs in test setup")
+
+	f := fObj.(*torbox.Fs)
+	// Replace the Fs.Srv with a new client pointing to the *same* test server
+	// for subsequent calls within the test. The server's handler might need to be
+	// updated by the test if subsequent calls hit different paths.
+	newSrvClient := server.Client()
+	f.Srv = rest.NewClient(fshttp.NewClientWithClient(context.Background(), newSrvClient)).SetRoot(server.URL)
+	f.Srv.SetHeader("Authorization", "Bearer dummy-test-token") // Re-apply auth header
+
+	return f, server, cleanup
+}
+
+
+func TestList_Root(t *testing.T) {
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("TestList_Root: Handler received %s %s", r.Method, r.URL.Path)
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123, "email": "test@example.com", "storage_bytes_total": 1000, "storage_bytes_used": 200}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/mylist" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[
+				{"id": 1, "hash": "hash1", "name": "Torrent One", "size_bytes": 1024, "created_at": "2023-01-01T12:00:00Z"},
+				{"id": 2, "hash": "hash2", "name": "Torrent Two", "size_bytes": 2048, "created_at": "2023-01-02T13:00:00Z"}
+			]`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestList_Root: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+
+	f, _, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+
+	entries, err := f.List(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	assert.Equal(t, "hash1", entries[0].Remote())
+	assert.Equal(t, fs.EntryDirectory, entries[0].Type())
+	assert.Equal(t, int64(1024), entries[0].Size())
+	assert.Equal(t, time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC), entries[0].ModTime(context.Background()))
+
+	assert.Equal(t, "hash2", entries[1].Remote())
+	assert.Equal(t, fs.EntryDirectory, entries[1].Type())
+	assert.Equal(t, int64(2048), entries[1].Size())
+}
+
+
+func TestList_TorrentContents(t *testing.T) {
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123, "email": "test@example.com"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" {
+			if r.URL.Query().Get("hash") == "test_hash" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": 10, "hash": "test_hash", "name": "Test Torrent", "size_bytes": 600,
+					"created_at": "2023-01-03T10:00:00Z",
+					"files": [
+						{"id": 101, "path": "video.mp4", "name": "video.mp4", "size_bytes": 500},
+						{"id": 102, "path": "docs/document.pdf", "name": "document.pdf", "size_bytes": 100}
+					]
+				}`))
+				return
+			}
+		}
+		http.Error(w, fmt.Sprintf("TestList_TorrentContents: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+	f, _, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+
+	entries, err := f.List(context.Background(), "test_hash")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	foundVideo, foundPdf := false, false
+	for _, entry := range entries {
+		obj, ok := entry.(fs.Object)
+		require.True(t, ok)
+		if obj.Remote() == "test_hash/video.mp4" {
+			foundVideo = true
+			assert.Equal(t, int64(500), obj.Size())
+			assert.Equal(t, time.Date(2023, 1, 3, 10, 0, 0, 0, time.UTC), obj.ModTime(context.Background()))
+		} else if obj.Remote() == "test_hash/document.pdf" {
+			foundPdf = true
+			assert.Equal(t, int64(100), obj.Size())
+		}
+	}
+	assert.True(t, foundVideo, "video.mp4 not found")
+	assert.True(t, foundPdf, "document.pdf not found")
+}
+
+func TestOpen_Success(t *testing.T) {
+	var actualDownloadURL string // To capture the URL from requestdl mock
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" { // For NewObject
+			if r.URL.Query().Get("hash") == "dl_test_hash" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": 20, "hash": "dl_test_hash", "name": "Download Test", "created_at": "2023-01-01T00:00:00Z", "size_bytes": 11,
+					"files": [{"id": 201, "path": "testfile.dat", "name": "testfile.dat", "size_bytes": 11}]
+				}`))
+				return
+			}
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/requestdl" { // For Open
+			assert.Equal(t, "dummy-test-token", r.URL.Query().Get("token"))
+			assert.Equal(t, "20", r.URL.Query().Get("torrent_id"))
+			assert.Equal(t, "201", r.URL.Query().Get("file_id"))
+
+			actualDownloadURL = "/downloads/actual_file.dat"
+			respJSON := fmt.Sprintf(`{"url": "%s%s"}`, "http://"+r.Host, actualDownloadURL)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(respJSON))
+			return
+		}
+		if actualDownloadURL != "" && r.Method == "GET" && r.URL.Path == actualDownloadURL { // Actual download
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte("hello world"))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestOpen_Success: Unhandled path %s or query %s", r.URL.Path, r.URL.RawQuery), http.StatusNotFound)
+	}
+
+	f, server, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+
+	// The Fs.Srv is already pointing to the test server by setupTestFs for subsequent calls.
+	// We just need to ensure the handler in the server can handle all expected calls.
+	// We update the server's handler to ensure it can serve the download URL.
+	server.Config.Handler = http.HandlerFunc(mockHandler)
+
+
+	obj, err := f.NewObject(context.Background(), "dl_test_hash/testfile.dat")
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	assert.Equal(t, int64(11), obj.Size())
+
+	rc, err := obj.Open(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+}
+
+
+func TestPurge_Success(t *testing.T) {
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" && r.URL.Query().Get("hash") == "purge_hash" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id": 30, "hash": "purge_hash", "name": "Torrent to Purge", "size_bytes": 0, "created_at": "2023-01-01T00:00:00Z", "files":[]}`))
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/v1/api/torrents/controltorrent" {
+			bodyBytes, _ := io.ReadAll(r.Body)
+			var payload torbox.ControlTorrentPayload
+			err := json.Unmarshal(bodyBytes, &payload)
+			require.NoError(t, err, "Failed to unmarshal payload")
+			assert.Equal(t, int64(30), payload.TorrentID)
+			assert.Equal(t, "delete", payload.Operation)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status": "success"}`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestPurge_Success: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+	f, server, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+	server.Config.Handler = http.HandlerFunc(mockHandler) // Ensure server uses the full handler
+
+	err := f.Purge(context.Background(), "purge_hash")
+	assert.NoError(t, err)
+}
+
+func TestRmdir_Success(t *testing.T) {
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" && r.URL.Query().Get("hash") == "rmdir_hash" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id": 40, "hash": "rmdir_hash", "name": "Torrent to Rmdir", "size_bytes":0, "created_at":"2023-01-01T00:00:00Z", "files":[]}`))
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/v1/api/torrents/controltorrent" {
+			bodyBytes, _ := io.ReadAll(r.Body)
+			var payload torbox.ControlTorrentPayload
+			err := json.Unmarshal(bodyBytes, &payload)
+			require.NoError(t, err)
+			assert.Equal(t, int64(40), payload.TorrentID)
+			assert.Equal(t, "delete", payload.Operation)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status": "success"}`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestRmdir_Success: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+	f, server, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+	server.Config.Handler = http.HandlerFunc(mockHandler)
+
+	err := f.Rmdir(context.Background(), "rmdir_hash")
+	assert.NoError(t, err)
+}
+
+func TestPut_TorrentFile(t *testing.T) {
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123}`))
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/v1/api/torrents/createtorrent" {
+			err := r.ParseMultipartForm(32 << 20)
+			require.NoError(t, err)
+
+			file, fh, err := r.FormFile("file")
+			require.NoError(t, err)
+			defer func() { _ = file.Close() }()
+			assert.Equal(t, "local.torrent", fh.Filename)
+			assert.Equal(t, "local.torrent", r.FormValue("name"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id": 50, "hash": "new_torrent_hash", "name": "local.torrent"}`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestPut_TorrentFile: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+	f, server, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+	server.Config.Handler = http.HandlerFunc(mockHandler)
+
+	dummyTorrentContent := []byte("dummy torrent file content")
+	src := fstest.NewObject("local.torrent", time.Now(), dummyTorrentContent)
+
+	obj, err := f.Put(context.Background(), bytes.NewReader(dummyTorrentContent), src)
+	assert.NoError(t, err)
+	assert.Nil(t, obj)
+}
+
+func TestPut_MagnetLink(t *testing.T) {
+	magnet := "magnet:?xt=urn:btih:somehashvalue"
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_id": 123}`))
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/v1/api/torrents/createtorrent" {
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, magnet, r.FormValue("magnet"))
+			assert.Equal(t, "myfave.magnet", r.FormValue("name"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id": 60, "hash": "magnet_hash", "name": "Magnet Torrent Name"}`))
+			return
+		}
+		http.Error(w, fmt.Sprintf("TestPut_MagnetLink: Unhandled path %s", r.URL.Path), http.StatusNotFound)
+	}
+	f, server, cleanup := setupTestFs(t, mockHandler)
+	defer cleanup()
+	server.Config.Handler = http.HandlerFunc(mockHandler)
+
+	src := fstest.NewObject("myfave.magnet", time.Now(), []byte(magnet))
+
+	obj, err := f.Put(context.Background(), strings.NewReader(magnet), src)
+	assert.NoError(t, err)
+	assert.Nil(t, obj)
+}
+
+// TestPut_UnsupportedFile, TestList_NonExistentTorrent, TestNewObject_NotFound
+// can remain largely the same as their core logic (error checking)
+// doesn't heavily depend on the exact structure of successful responses,
+// but their /user/me mocks should align for setupTestFs.
+
+func TestPut_UnsupportedFile(t *testing.T) {
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+            w.Header().Set("Content-Type", "application/json")
+            _, _ = w.Write([]byte(`{"user_id": 123}`)) // For setupTestFs
+            return
+        }
+        http.Error(w, "TestPut_UnsupportedFile: This should not be called for unsupported files", http.StatusInternalServerError)
+    }
+
+    f, _, cleanup := setupTestFs(t, handler)
+    defer cleanup()
+
+    randomContent := []byte("this is not a torrent or magnet")
+    src := fstest.NewObject("myfile.zip", time.Now(), randomContent)
+
+    _, err := f.Put(context.Background(), bytes.NewReader(randomContent), src)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "TorBox backend only supports adding .torrent files or magnet links")
+}
+
+func TestList_NonExistentTorrent(t *testing.T) {
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+            w.Header().Set("Content-Type", "application/json")
+            _, _ = w.Write([]byte(`{"user_id": 123, "email": "test@example.com"}`))
+            return
+        }
+        if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" {
+            if r.URL.Query().Get("hash") == "non_existent_hash" {
+                http.Error(w, "Torrent not found", http.StatusNotFound) // getTorrentInfoByHash will error
+                return
+            }
+        }
+        http.Error(w, fmt.Sprintf("TestList_NonExistentTorrent: Unhandled path %s", r.URL.Path), http.StatusInternalServerError)
+    })
+
+    f, _, cleanup := setupTestFs(t, handler)
+    defer cleanup()
+
+    _, err := f.List(context.Background(), "non_existent_hash")
+    require.Error(t, err)
+    // This error comes from getTorrentInfoByHash failing and List propagating it.
+    // If getTorrentInfoByHash maps to fs.ErrorObjectNotFound, then List might map to fs.ErrorDirNotFound.
+    // Current torbox.go maps "received empty or invalid torrent info" to fs.ErrorDirNotFound in List.
+    // A StatusNotFound from http.Error will likely result in a generic "failed to get torrent info" or similar.
+    assert.Contains(t, err.Error(), "failed to get torrent info")
+}
+
+func TestNewObject_NotFound(t *testing.T) {
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        if r.Method == "GET" && r.URL.Path == "/v1/api/user/me" {
+            w.Header().Set("Content-Type", "application/json")
+            _, _ = w.Write([]byte(`{"user_id": 123}`))
+            return
+        }
+        if r.Method == "GET" && r.URL.Path == "/v1/api/torrents/torrentinfo" {
+            queryHash := r.URL.Query().Get("hash")
+            if queryHash == "bad_hash" {
+                http.Error(w, "Torrent not found", http.StatusNotFound) // getTorrentInfoByHash will error
+                return
+            }
+            if queryHash == "good_hash_no_file" {
+                w.Header().Set("Content-Type", "application/json")
+                // Torrent exists, but file won't be in "files"
+                _, _ = w.Write([]byte(`{"id":70, "hash":"good_hash_no_file", "name":"Good Torrent", "files":[]}`))
+                return
+            }
+        }
+        http.Error(w, fmt.Sprintf("TestNewObject_NotFound: Unhandled path %s", r.URL.Path), http.StatusInternalServerError)
+    })
+
+    f, _, cleanup := setupTestFs(t, handler)
+    defer cleanup()
+
+    _, err := f.NewObject(context.Background(), "bad_hash/file.txt")
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "failed to get torrent info")
+
+    _, err = f.NewObject(context.Background(), "good_hash_no_file/non_existent_file.txt")
+    require.Error(t, err)
+    assert.Equal(t, fs.ErrorObjectNotFound, err) // Should be specific if torrent found but file not.
+}
+
+// Note: The `setupTestFs` helper was refactored to use a global HTTP client override (`activateMockHTTPClient`)
+// for the NewFs call, and then replace Fs.Srv for subsequent calls. This is still complex.
+// Ideal solution: torbox.NewFs accepts *http.Client or a base URL.
+// The Object.Name() assertion style `obj.(*torbox.Object).Name()` would require tests to be in `package torbox`
+// or for `Name` to be an exported field or method of `torbox.Object`. For `fs.Object` interface, only `Remote()` is standard.
+// Assertions for specific struct fields (e.g. torrentID, fileID on Object) are not done as these are internal details
+// not exposed by fs.Object or fs.DirEntry, but their correct usage is implicitly tested by params sent to mock APIs.

--- a/docs/content/torbox.md
+++ b/docs/content/torbox.md
@@ -1,0 +1,108 @@
+---
+title: "TorBox"
+description: "Rclone backend for TorBox file storage."
+version: "vX.Y" # Rclone version - adjust when released
+status: "beta"  # Current status
+supports_server_side: ["delete"] # "delete" for torrents (directories)
+options:
+- name: "api_token"
+  description: |
+    Your TorBox API Token. This is required to authenticate with the TorBox API.
+    See below for instructions on how to obtain this token.
+  required: true
+  example: "your_actual_api_token_value_here"
+  obscure: true # Mark as sensitive
+---
+
+# TorBox
+
+[TorBox](https://torbox.app/) is a service that allows you to download torrents and other files from the internet to your private cloud storage space. This rclone backend enables you to manage and access the files stored within your TorBox account, primarily focusing on listing torrents and the files they contain, downloading these files, and managing your torrents by adding or deleting them.
+
+## Configuration
+
+To configure a TorBox remote for rclone, run `rclone config` and follow the interactive prompts. You will need your **API Token**.
+
+### Obtaining your API Token
+
+The TorBox API uses a bearer token for authentication. Obtaining this `api_token` is a multi-step process:
+
+1.  **Log in to your TorBox account:** Open your web browser and log in at [https://torbox.app/](https://torbox.app/).
+2.  **Access Developer Tools:** Once logged in, open your browser's developer tools. This is typically done by pressing `F12`.
+3.  **Find your Session Token:**
+    *   Navigate to the 'Application' (in Chrome/Edge) or 'Storage' (in Firefox) tab within the developer tools.
+    *   Look for 'Cookies' in the sidebar and select the cookie(s) associated with `torbox.app` or `www.torbox.app`.
+    *   Find a cookie named `session_token` (or a similar name like `connect.sid`). Copy its value. This is your temporary session token.
+4.  **Exchange Session Token for API Token:** Use a command-line tool like `curl` to exchange your `session_token` for a long-lived `api_token`. Replace `YOUR_SESSION_TOKEN_HERE` with the actual value you copied:
+    ```bash
+    curl -X POST -H "Content-Type: application/json" \
+         -d '{"session_token": "YOUR_SESSION_TOKEN_HERE"}' \
+         https://api.torbox.app/v1/api/user/refreshtoken
+    ```
+5.  **Extract API Token:** The response from the `curl` command will be a JSON object. Look for a field named `token` (or `api_token`). This is your `api_token` for rclone.
+    Example response: `{"token":"your_actual_api_token_value_here", "other_field": "..."}`
+6.  **Use in Rclone Config:** Enter this `api_token` when prompted during `rclone config`.
+
+**Example rclone.conf entry:**
+```ini
+[torbox_remote]
+type = torbox
+api_token = your_actual_api_token_value_here
+```
+
+## Path Handling and Object Model
+
+The TorBox backend models your torrents and their contents as follows:
+
+*   **Torrents as Directories:** Each torrent in your TorBox account is represented as a "directory" in rclone.
+*   **Directory Naming:** The names of these torrent "directories" are currently formed using the **torrent's hash**. For example, if a torrent has the hash `a1b2c3d4...`, it will appear as a directory named `a1b2c3d4...`.
+    *   You can list these torrent directories using `rclone lsd torbox_remote:`.
+*   **Files within Torrents:** Files contained within a torrent are listed inside their corresponding torrent hash "directory".
+    *   For example, to list files in the torrent with hash `a1b2c3d4...`, you would use `rclone ls torbox_remote:/a1b2c3d4.../`.
+*   **File Paths:** The full remote path to a file within a torrent typically looks like `TORRENT_HASH/path/to/file_in_torrent.ext`. The `path/to/file_in_torrent.ext` part reflects the file's path as it is structured inside the torrent.
+
+## Core Operations
+
+*   **Listing Torrents:**
+    *   `rclone lsd torbox_remote:` - Lists all active torrents (as directories named by their hash).
+*   **Listing Files in a Torrent:**
+    *   `rclone ls torbox_remote:/TORRENT_HASH/` - Lists files and subdirectories within the specified torrent.
+    *   `rclone lsjson torbox_remote:/TORRENT_HASH/` - Provides detailed JSON output for files.
+*   **Downloading Files:**
+    *   `rclone copy torbox_remote:/TORRENT_HASH/path/to/file.txt /local/destination/` - Downloads a specific file.
+*   **Adding New Torrents:**
+    *   This backend allows you to add new torrents to your TorBox account using `.torrent` files or magnet links. This operation registers the torrent with TorBox for downloading; it does not upload the torrent's actual data content via rclone.
+    *   **Using a `.torrent` file:**
+        ```bash
+        rclone copy mylocal.torrent torbox_remote:mylocal.torrent
+        ```
+        The name given on the remote side (e.g., `mylocal.torrent`) is primarily for rclone's operation tracking. TorBox will identify the torrent based on its metadata content, and the name appearing in listings will be derived from that or the torrent hash.
+    *   **Using a magnet link:**
+        1.  Save your complete magnet URI into a plain text file (e.g., `mymagnet.txt`).
+        2.  Copy this file to the remote, ensuring the remote filename ends with `.magnet`:
+            ```bash
+            rclone copy mymagnet.txt torbox_remote:desired_name.magnet
+            ```
+            Rclone reads the content of the source file (`mymagnet.txt`) and sends it as the magnet link to TorBox. The `desired_name.magnet` is for rclone's path handling.
+*   **Deleting Torrents:**
+    *   To delete an entire torrent and all its files from your TorBox account:
+        ```bash
+        rclone purge torbox_remote:/TORRENT_HASH
+        ```
+        or
+        ```bash
+        rclone rmdir torbox_remote:/TORRENT_HASH
+        ```
+    *   **Important:** Deleting individual files within a torrent (e.g., `rclone deletefile remote:TORRENT_HASH/file.txt`) is **not supported** due to limitations in the TorBox API.
+
+## Limitations
+
+*   **No Individual File Deletion:** As stated above, individual files within an existing torrent cannot be deleted via rclone due to API limitations. You must delete the entire torrent and re-add it if you wish to exclude certain files.
+*   **Uploads Limited to Torrents/Magnets:** The `rclone copy` command, when copying *to* the TorBox remote, is only for adding new `.torrent` files or magnet links. It does not support uploading arbitrary files (e.g., a ZIP archive or a video file) to be converted into new torrents or stored directly.
+*   **No Server-Side Copy/Move:** Server-side copy (`rclone copy remote:file1 remote:file2`) and server-side move (`rclone move remote:file1 remote:file2`) operations for files within or between torrents are not supported. Torrent "directories" also cannot be copied or moved server-side.
+*   **Modification Times (`ModTime`):** The modification time for files listed within a torrent is derived from the **torrent's creation time** on TorBox. Individual files do not expose their original modification times via the API. The precision of this reported time is per second.
+*   **File Hashes:** The TorBox API does not provide checksum hashes (like MD5, SHA1) for individual files within torrents. Therefore, `rclone sha1sum`, `rclone md5sum`, etc., will show "Unsupported" for files on this backend.
+*   **Storage Quota Information (`rclone about`):** The information displayed by `rclone about torbox_remote:` regarding total and used storage space is based on what the TorBox API (`/v1/api/user/me`) provides. If certain fields (like total, free, or object count) are not available or are returned as null/zero by the API, they may appear as -1 (unknown) or 0 in the `rclone about` output.
+*   **Directory Modification Times:** The modification time for torrent "directories" (listed by `rclone lsd`) is the creation time of the torrent.
+
+---
+Standard options like `type` and `api_token` are described above. There are currently no other backend-specific advanced options for TorBox. For general rclone options, please refer to the main rclone documentation.


### PR DESCRIPTION
This commit introduces a new backend for TorBox (torbox.app).

TorBox is a service that allows you to download torrents and other files to your private cloud space. This rclone backend enables you to manage your TorBox torrents.

Key Features:
- List torrents (as directories, named by torrent hash).
- List files within torrents.
- Download files from torrents.
- Add new torrents to TorBox via .torrent files or magnet links (using `rclone copy` with a .torrent or .magnet file extension on the remote).
- Delete entire torrents from TorBox (using `rclone purge` or `rclone rmdir` on the torrent hash directory).

Authentication:
- Uses an API token obtained from TorBox. The process involves retrieving a session_token from the website and exchanging it for an api_token via a curl command, as detailed in the documentation.

Limitations:
- The TorBox API does not support deleting individual files within an existing torrent. Only entire torrents can be deleted.
- Uploading arbitrary files (that are not .torrent files or magnet links) to be converted into new torrents by rclone is not supported.
- Server-side copy and move operations are not supported.
- File modification times are based on the torrent's creation time.
- Specific file hashes (MD5, SHA1) are not available from the API.
- Quota information from `rclone about` may be limited.

The backend includes unit tests that mock API interactions. Full CI validation is currently blocked by an unrelated pre-existing build issue in the azureblob backend.